### PR TITLE
Do not limit Observation Compose support to bridged @Observables

### DIFF
--- a/Sources/SkipBridge/Observation.swift
+++ b/Sources/SkipBridge/Observation.swift
@@ -65,17 +65,11 @@ private final class BridgeObservationSupport: @unchecked Sendable {
     }
 
     public func access<Subject, Member>(_ subject: Subject, keyPath: KeyPath<Subject, Member>) {
-        guard subject is BridgedToKotlin else {
-            return
-        }
         let index = Java_init(forKeyPath: keyPath)
         Java_access(index)
     }
 
     public func willSet<Subject, Member>(_ subject: Subject, keyPath: KeyPath<Subject, Member>) {
-        guard subject is BridgedToKotlin else {
-            return
-        }
         let index = Java_init(forKeyPath: keyPath)
         Java_update(index)
     }

--- a/Sources/SkipBridgeToKotlinSamples/Samples.swift
+++ b/Sources/SkipBridgeToKotlinSamples/Samples.swift
@@ -167,6 +167,10 @@ public final class SwiftHelperClass: SwiftProtocol, SwiftGenericProtocol, Compar
         return p + 1
     }
 
+    @MainActor public func mainActorFunc(p: Int) -> Int {
+        return p
+    }
+
     public static func ==(lhs: SwiftHelperClass, rhs: SwiftHelperClass) -> Bool {
         return lhs.stringVar == rhs.stringVar
     }
@@ -264,6 +268,7 @@ public enum SwiftAssociatedValuesEnum {
 
 public class SwiftGenericClass<T> {
     public var value: T
+    @MainActor public var mainActorValue: T? = nil
 
     // SKIP @nobridge
     public init(value: T) {


### PR DESCRIPTION
This prevented use for unbridged @Observable types with SkipFuseUI
