### PR TITLE
Use package skip.bridge rather than tools.skip.bridge for R8 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Released 2025-01-23
 
-  - Add TARGET_OS_ANDROID envrionment and compiler directive to Android build (#50)
+  - Add TARGET_OS_ANDROID environment and compiler directive to Android build (#50)
 
 ## 0.2.1
 

--- a/Sources/SkipBridge/AnyDynamicObject.swift
+++ b/Sources/SkipBridge/AnyDynamicObject.swift
@@ -219,7 +219,7 @@ open class AnyDynamicObject: JObjectProtocol, JConvertible {
     }
 }
 
-private let Java_reflectorClass = try! JClass(name: "tools.skip.bridge.Reflector")
+private let Java_reflectorClass = try! JClass(name: "skip.bridge.Reflector")
 private let Java_reflectorConstructor = Java_reflectorClass.getMethodID(name: "<init>", sig: "(Ljava/lang/Object;)V")!
 private let Java_reflectorClassNameConstructor = Java_reflectorClass.getMethodID(name: "<init>", sig: "(Ljava/lang/String;Ljava/util/List;)V")!
 private let Java_reflectorStaticsOfClassNameConstructor = Java_reflectorClass.getMethodID(name: "<init>", sig: "(Ljava/lang/String;)V")!

--- a/Sources/SkipBridge/Skip/Reflector.kt
+++ b/Sources/SkipBridge/Skip/Reflector.kt
@@ -1,6 +1,6 @@
 // Copyright 2024–2025 Skip
 // SPDX-License-Identifier: LGPL-3.0-only WITH LGPL-3.0-linking-exception
-package tools.skip.bridge
+package skip.bridge
 
 import kotlin.reflect.*
 import kotlin.reflect.full.*


### PR DESCRIPTION
The package name for the Reflector class used by `AnyDynamicBridge` is `tools.skip.bridge`, which is not covered by the default `proguard-rules.pro` set (which only keeps `skip.bridge.**`. This leads to a crash in release builds when dynamic bridging is used:

```
SkipBridge/AnyDynamicObject.swift:222: Fatal error: 'try!' expression unexpectedly raised an error: java.lang.ClassNotFoundException: Didn't find class "tools.skip.bridge.Reflector" on path: DexPathList[[zip file "/data/app/~~SbH0Yy7TJwtx38PAihVkAQ==/org.appfair.app.Showcase-DByEHgQKbe5TuiO-EdEsUQ==/base.apk", zip file "/data/app/~~SbH0Yy7TJwtx38PAihVkAQ==/org.appfair.app.Showcase-DByEHgQKbe5TuiO-EdEsUQ==/split_config.arm64_v8a.apk", zip file "/data/app/~~SbH0Yy7TJwtx38PAihVkAQ==/org.appfair.app.Showcase-DByEHgQKbe5TuiO-EdEsUQ==/split_config.en.apk", zip file "/data/app/~~SbH0Yy7TJwtx38PAihVkAQ==/org.appfair.app.Showcase-DByEHgQKbe5TuiO-EdEsUQ==/split_config.xxxhdpi.apk"],nativeLibraryDirectories=[/data/app/~~SbH0Yy7TJwtx38PAihVkAQ==/org.appfair.app.Showcase-DByEHgQKbe5TuiO-EdEsUQ==/lib/arm64, /data/app/~~SbH0Yy7TJwtx38PAihVkAQ==/org.appfair.app.Showcase-DByEHgQKbe5TuiO-EdEsUQ==/base.apk!/lib/arm64-v8a, /data/app/~~SbH0Yy7TJwtx38PAihVkAQ==/org.appfair.app.Showcase-DByEHgQKbe5TuiO-EdEsUQ==/split_config.arm64_

*** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
pid: 0, tid: 22711 >>> org.appfair.app.Showcase <<<

backtrace:
  #00  pc 0x0000000000353d84  /data/app/~~SbH0Yy7TJwtx38PAihVkAQ==/org.appfair.app.Showcase-DByEHgQKbe5TuiO-EdEsUQ==/lib/arm64/libswiftCore.so ($ss17_assertionFailure__4file4line5flagss5NeverOs12StaticStringV_SSAHSus6UInt32VtF+164) (BuildId: f673ad45c51559678b698fe2be1e9e17c5288139)
  #01  pc 0x0000000000386738  /data/app/~~SbH0Yy7TJwtx38PAihVkAQ==/org.appfair.app.Showcase-DByEHgQKbe5TuiO-EdEsUQ==/lib/arm64/libswiftCore.so (swift_unexpectedError+668) (BuildId: f673ad45c51559678b698fe2be1e9e17c5288139)
  #02  pc 0x000000000002b4cc  /data/app/~~SbH0Yy7TJwtx38PAihVkAQ==/org.appfair.app.Showcase-DByEHgQKbe5TuiO-EdEsUQ==/lib/arm64/libSkipBridge.so ($s10SkipBridge19Java_reflectorClass33_5AF8B9D71D039534CBF463DC3E452E9FLL_WZ+116) (BuildId: dff16c53292e9f22731588ea396964b21b8fe029)
  #03  pc 0x000000000052d210  /data/app/~~SbH0Yy7TJwtx38PAihVkAQ==/org.appfair.app.Showcase-DByEHgQKbe5TuiO-EdEsUQ==/lib/arm64/libswiftCore.so (swift::threading_impl::once_slow(std::__ndk1::atomic<long>&, void (*)(void*), void*)+56) (BuildId: f673ad45c51559678b698fe2be1e9e17c5288139)
  #04  pc 0x0000000000028820  /data/app/~~SbH0Yy7TJwtx38PAihVkAQ==/org.appfair.app.Showcase-DByEHgQKbe5TuiO-EdEsUQ==/lib/arm64/libSkipBridge.so ($s10SkipBridge16AnyDynamicObjectC3for7optionsACSv_8SwiftJNI19JConvertibleOptionsVtKcfcyyKXEfU_+60) (BuildId: dff16c53292e9f22731588ea396964b21b8fe029)
  #05  pc 0x0000000000028918  /data/app/~~SbH0Yy7TJwtx38PAihVkAQ==/org.appfair.app.Showcase-DByEHgQKbe5TuiO-EdEsUQ==/lib/arm64/libSkipBridge.so ($s10SkipBridge16AnyDynamicObjectC3for7optionsACSv_8SwiftJNI19JConvertibleOptionsVtKcfcyyKXEfU_TA+16) (BuildId: dff16c53292e9f22731588ea396964b21b8fe029)
  #06  pc 0x000000000002fdb8  /data/app/~~SbH0Yy7TJwtx38PAihVkAQ==/org.appfair.app.Showcase-DByEHgQKbe5TuiO-EdEsUQ==/lib/arm64/libSkipBridge.so ($s10SkipBridge16AnyDynamicObjectC3for7optionsACSv_8SwiftJNI19JConvertibleOptionsVtKcfcyyKXEfU_TA.3+8) (BuildId: dff16c53292e9f22731588ea396964b21b8fe029)
  #07  pc 0x000000000003b5f8  /data/app/~~SbH0Yy7TJwtx38PAihVkAQ==/org.appfair.app.Showcase-DByEHgQKbe5TuiO-EdEsUQ==/lib/arm64/libSwiftJNI.so ($s8SwiftJNI10jniContextyxxyKXEKlF+232) (BuildId: 73cb8084feda80fe455e9e2ce8088eeacf70b438)
  #08  pc 0x00000000000302f8  /data/app/~~SbH0Yy7TJwtx38PAihVkAQ==/org.appfair.app.Showcase-DByEHgQKbe5TuiO-EdEsUQ==/lib/arm64/libSkipBridge.so ($s10SkipBridge16AnyDynamicObjectC3for7optionsACSv_8SwiftJNI19JConvertibleOptionsVtKcfc+60) (BuildId: dff16c53292e9f22731588ea396964b21b8fe029)
  #09  pc 0x000000000007a19c  /data/app/~~SbH0Yy7TJwtx38PAihVkAQ==/org.appfair.app.Showcase-DByEHgQKbe5TuiO-EdEsUQ==/lib/arm64/libSkipAndroidBridge.so ($s17SkipAndroidBridge16AssetURLProtocolC8registeryyKFZTf4d_n+260) (BuildId: 0fc5b3603279234328f38e08f2cbd921946d02ca)
  #10  pc 0x000000000006aaa8  /data/app/~~SbH0Yy7TJwtx38PAihVkAQ==/org.appfair.app.Showcase-DByEHgQKbe5TuiO-EdEsUQ==/lib/arm64/libSkipAndroidBridge.so ($s17SkipAndroidBridge0bC9BootstrapC04initbC08filesDir05cacheG0ySS_SStKFZTf4nnd_n+312) (BuildId: 0fc5b3603279234328f38e08f2cbd921946d02ca)
  #11  pc 0x000000000006bb04  /data/app/~~SbH0Yy7TJwtx38PAihVkAQ==/org.appfair.app.Showcase-DByEHgQKbe5TuiO-EdEsUQ==/lib/arm64/libSkipAndroidBridge.so (Java_skip_android_bridge_AndroidBridgeBootstrap_00024Companion_Swift_1Companion_1initAndroidBridge_10+84) (BuildId: 0fc5b3603279234328f38e08f2cbd921946d02ca)
  #12  pc 0x00000000000aec7c  /system/framework/arm64/boot.oat (art_jni_trampoline+140)
  #13  pc 0x0000000000781020  /apex/com.android.art/lib64/libart.so (nterp_helper+4016)
  #14  pc 0x000000000023f2f8  /data/app/~~SbH0Yy7TJwtx38PAihVkAQ==/org.appfair.app.Showcase-DByEHgQKbe5TuiO-EdEsUQ==/base.apk (skip.android.bridge.AndroidBridgeBootstrap$Companion.initAndroidBridge+20)
  #15  pc 0x0000000000780fc4  /apex/com.android.art/lib64/libart.so (nterp_helper+3924)
  #16  pc 0x000000000023f248  /data/app/~~SbH0Yy7TJwtx38PAihVkAQ==/org.appfair.app.Showcase-DByEHgQKbe5TuiO-EdEsUQ==/base.apk (skip.android.bridge.AndroidBridge$Companion.initBridge+280)
  #17  pc 0x0000000000368774  /apex/com.android.art/lib64/libart.so (art_quick_invoke_stub+612)
  #18  pc 0x0000000000364414  /apex/com.android.art/lib64/libart.so (_jobject* art::InvokeMethod<(art::PointerSize)8>(art::ScopedObjectAccessAlreadyRunnable const&, _jobject*, _jobject*, _jobject*, unsigned long)+540)
  #19  pc 0x00000000006c9298  /apex/com.android.art/lib64/libart.so (art::Method_invoke(_JNIEnv*, _jobject*, _jobject*, _jobjectArray*) (.__uniq.165753521025965369065708152063621506277)+32)
  #20  pc 0x00000000000ae154  /system/framework/arm64/boot.oat (art_jni_trampoline+116)
  #21  pc 0x0000000000781020  /apex/com.android.art/lib64/libart.so (nterp_helper+4016)
  #22  pc 0x000000000014b3f0  /data/app/~~SbH0Yy7TJwtx38PAihVkAQ==/org.appfair.app.Showcase-DByEHgQKbe5TuiO-EdEsUQ==/base.apk (kotlin.reflect.jvm.internal.calls.i$h.f+32)
  #23  pc 0x0000000000780fc4  /apex/com.android.art/lib64/libart.so (nterp_helper+3924)
  #24  pc 0x000000000014b2a6  /data/app/~~SbH0Yy7TJwtx38PAihVkAQ==/org.appfair.app.Showcase-DByEHgQKbe5TuiO-EdEsUQ==/base.apk (kotlin.reflect.jvm.internal.calls.i$h$e.v+46)
  #25  pc 0x0000000000781de4  /apex/com.android.art/lib64/libart.so (nterp_helper+7540)
  #26  pc 0x000000000013d43e  /data/app/~~SbH0Yy7TJwtx38PAihVkAQ==/org.appfair.app.Showcase-DByEHgQKbe5TuiO-EdEsUQ==/base.apk (kotlin.reflect.jvm.internal.z.v+18)
  #27  pc 0x0000000000781de4  /apex/com.android.art/lib64/libart.so (nterp_helper+7540)
  #28  pc 0x0000000000230e5a  /data/app/~~SbH0Yy7TJwtx38PAihVkAQ==/org.appfair.app.Showcase-DByEHgQKbe5TuiO-EdEsUQ==/base.apk (skip.foundation.ProcessInfo$Companion.launch+422)
  #29  pc 0x0000000000780fc4  /apex/com.android.art/lib64/libart.so (nterp_helper+3924)
  #30  pc 0x00000000000cbcf6  /data/app/~~SbH0Yy7TJwtx38PAihVkAQ==/org.appfair.app.Showcase-DByEHgQKbe5TuiO-EdEsUQ==/base.apk (showcase.fuse.AndroidAppMain.onCreate+46)
  #31  pc 0x000000000027f9f0  /system/framework/arm64/boot-framework.oat (android.app.Instrumentation.callApplicationOnCreate+48)
  #32  pc 0x000000000035fd08  /system/framework/arm64/boot-framework.oat (android.app.ActivityThread.handleBindApplication+5336)
  #33  pc 0x0000000000358ca0  /system/framework/arm64/boot-framework.oat (android.app.ActivityThread$H.handleMessage+8736)
  #34  pc 0x00000000005da3cc  /system/framework/arm64/boot-framework.oat (android.os.Handler.dispatchMessage+140)
  #35  pc 0x00000000005df3a4  /system/framework/arm64/boot-framework.oat (android.os.Looper.loopOnce+1268)
  #36  pc 0x00000000005dee28  /system/framework/arm64/boot-framework.oat (android.os.Looper.loop+296)
  #37  pc 0x000000000036a3a8  /system/framework/arm64/boot-framework.oat (android.app.ActivityThread.main+1736)
  #38  pc 0x0000000000368a40  /apex/com.android.art/lib64/libart.so (art_quick_invoke_static_stub+640)
  #39  pc 0x00000000003644d4  /apex/com.android.art/lib64/libart.so (_jobject* art::InvokeMethod<(art::PointerSize)8>(art::ScopedObjectAccessAlreadyRunnable const&, _jobject*, _jobject*, _jobject*, unsigned long)+732)
  #40  pc 0x00000000006c9298  /apex/com.android.art/lib64/libart.so (art::Method_invoke(_JNIEnv*, _jobject*, _jobject*, _jobjectArray*) (.__uniq.165753521025965369065708152063621506277)+32)
  #41  pc 0x00000000000ae154  /system/framework/arm64/boot.oat (art_jni_trampoline+116)
  #42  pc 0x000000000093fd54  /system/framework/arm64/boot-framework.oat (com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run+116)
  #43  pc 0x000000000094b8e8  /system/framework/arm64/boot-framework.oat (com.android.internal.os.ZygoteInit.main+5080)
  #44  pc 0x0000000000368a40  /apex/com.android.art/lib64/libart.so (art_quick_invoke_static_stub+640)
  #45  pc 0x0000000000353f4c  /apex/com.android.art/lib64/libart.so (art::ArtMethod::Invoke(art::Thread*, unsigned int*, unsigned int, art::JValue*, char const*)+204)
  #46  pc 0x0000000000351f00  /apex/com.android.art/lib64/libart.so (art::JValue art::InvokeWithVarArgs<_jmethodID*>(art::ScopedObjectAccessAlreadyRunnable const&, _jobject*, _jmethodID*, std::__va_list)+512)
  #47  pc 0x000000000073da58  /apex/com.android.art/lib64/libart.so (art::JNI<true>::CallStaticVoidMethodV(_JNIEnv*, _jclass*, _jmethodID*, std::__va_list)+104)
  #48  pc 0x00000000000e542c  /system/lib64/libandroid_runtime.so (_JNIEnv::CallStaticVoidMethod(_jclass*, _jmethodID*, ...)+108)
  #49  pc 0x00000000000fb9a8  /system/lib64/libandroid_runtime.so (android::AndroidRuntime::start(char const*, android::Vector<android::String8> const&, bool)+1008)
  #50  pc 0x00000000000046fc  /system/bin/app_process64 (main+1596)
  #51  pc 0x000000000008f684  /apex/com.android.runtime/lib64/bionic/libc.so (__libc_init+120)
```

This PR simply changes the package name from `tools.skip.bridge` to `skip.bridge`, which is covered by the default Proguard rules.